### PR TITLE
Update workflow-commands-for-github-actions.md

### DIFF
--- a/content/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions.md
+++ b/content/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions.md
@@ -652,7 +652,7 @@ echo "{environment_variable_name}={value}" >> "$GITHUB_ENV"
 * Using PowerShell version 6 and higher:
 
   ```powershell copy
-  "{environment_variable_name}={value}" | Out-File -FilePath $env:GITHUB_ENV -Append
+  "{environment_variable_name}={value}" >> $env:GITHUB_ENV
   ```
 
 * Using PowerShell version 5.1 and below:
@@ -698,7 +698,7 @@ steps:
   - name: Set the value
     id: step_one
     run: |
-      "action_state=yellow" | Out-File -FilePath $env:GITHUB_ENV -Append
+      "action_state=yellow" >> $env:GITHUB_ENV
   - name: Use the value
     id: step_two
     run: |
@@ -751,9 +751,9 @@ steps:
     id: step_one
     run: |
       $EOF = -join (1..15 | ForEach {[char]((48..57)+(65..90)+(97..122) | Get-Random)})
-      "JSON_RESPONSE<<$EOF" | Out-File -FilePath $env:GITHUB_ENV -Append
-      (Invoke-WebRequest -Uri "https://example.com").Content | Out-File -FilePath $env:GITHUB_ENV -Append
-      "$EOF" | Out-File -FilePath $env:GITHUB_ENV -Append
+      "JSON_RESPONSE<<$EOF" >> $env:GITHUB_ENV
+      (Invoke-WebRequest -Uri "https://example.com").Content >> $env:GITHUB_ENV
+      "$EOF" >> $env:GITHUB_ENV
     shell: pwsh
 ```
 
@@ -774,7 +774,7 @@ echo "{name}={value}" >> "$GITHUB_OUTPUT"
 {% powershell %}
 
 ```powershell copy
-"{name}=value" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+"{name}=value" >> $env:GITHUB_OUTPUT
 ```
 
 {% endpowershell %}
@@ -805,7 +805,7 @@ This example demonstrates how to set the `SELECTED_COLOR` output parameter and l
       - name: Set color
         id: color-selector
         run: |
-            "SELECTED_COLOR=green" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "SELECTED_COLOR=green" >> $env:GITHUB_OUTPUT
       - name: Get color
         env:{% raw %}
           SELECTED_COLOR: ${{ steps.color-selector.outputs.SELECTED_COLOR }}{% endraw %}
@@ -827,7 +827,7 @@ echo "{markdown content}" >> $GITHUB_STEP_SUMMARY
 {% powershell %}
 
 ```powershell copy
-"{markdown content}" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+"{markdown content}" >> $env:GITHUB_STEP_SUMMARY
 ```
 
 {% endpowershell %}
@@ -851,7 +851,7 @@ echo "### Hello world! :rocket:" >> $GITHUB_STEP_SUMMARY
 {% powershell %}
 
 ```powershell copy
-"### Hello world! :rocket:" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+"### Hello world! :rocket:" >> $env:GITHUB_STEP_SUMMARY
 ```
 
 {% endpowershell %}
@@ -883,11 +883,11 @@ For multiline Markdown content, you can use `>>` to continuously append content 
 ```yaml
 - name: Generate list using Markdown
   run: |
-    "This is the lead in sentence for the list" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-    "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append # this is a blank line
-    "- Lets add a bullet point" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-    "- Lets add a second bullet point" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-    "- How about a third one?" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+    "This is the lead in sentence for the list" >> $env:GITHUB_STEP_SUMMARY
+    "" >> $env:GITHUB_STEP_SUMMARY # this is a blank line
+    "- Lets add a bullet point" >> $env:GITHUB_STEP_SUMMARY
+    "- Lets add a second bullet point" >> $env:GITHUB_STEP_SUMMARY
+    "- How about a third one?" >> $env:GITHUB_STEP_SUMMARY
 ```
 
 {% endpowershell %}
@@ -914,8 +914,8 @@ To clear all content for the current step, you can use `>` to overwrite any prev
 ```yaml
 - name: Overwrite Markdown
   run: |
-    "Adding some Markdown content" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-    "There was an error, we need to clear the previous Markdown with some new content." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY
+    "Adding some Markdown content" >> $env:GITHUB_STEP_SUMMARY
+    "There was an error, we need to clear the previous Markdown with some new content." >> $env:GITHUB_STEP_SUMMARY
 ```
 
 {% endpowershell %}
@@ -942,7 +942,7 @@ To completely remove a summary for the current step, the file that `GITHUB_STEP_
 ```yaml
 - name: Delete all summary content
   run: |
-    "Adding Markdown content that we want to remove before the step ends" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+    "Adding Markdown content that we want to remove before the step ends" >> $env:GITHUB_STEP_SUMMARY
     Remove-Item $env:GITHUB_STEP_SUMMARY
 ```
 


### PR DESCRIPTION
### Why:

Currently, in the documentation for workflow-commands-for-github-actions it states that a valid use of PowerShell is:

 `"$Something" | Out-File -FilePath $env:GITHUB_ENV -Append`

However, this does not work for the hosted `Ubuntu-Latest` agents running with the `pwsh` shell.

### What's being changed:

I have updated all of the powershell commands on this page to be the working format of:

 `"$Something" >> $env:GITHUB_ENV`

Which I have tested produces consistent results.

I have left all older PowerShell commands and only updated the Powershell Core ones.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
